### PR TITLE
Remove OSX from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ d:
 
 os:
   - linux
-  - osx
+#  - osx
 
 env:
   - ARCH=x86_64


### PR DESCRIPTION
ldc on 32bit OSX now broken. So, remove from CI test case.

![image](https://user-images.githubusercontent.com/580704/60101640-133afe80-9797-11e9-9ee0-0560d8c70cdc.png)
